### PR TITLE
:recycle: Refactor: 크롤링 업데이트 로직 변경 및 성능 개선

### DIFF
--- a/src/main/java/com/fx/knutNotice/domain/AcademicNewsRepository.java
+++ b/src/main/java/com/fx/knutNotice/domain/AcademicNewsRepository.java
@@ -15,4 +15,7 @@ public interface AcademicNewsRepository  extends JpaRepository<AcademicNews, Lon
 
     @Query(value = "SELECT MIN(a.boardNumber) FROM AcademicNews a")
     Long findMinBoardNumber();
+
+    @Query(value = "SELECT MAX(a.nttId) FROM AcademicNews a")
+    Long findMaxNttId();
 }

--- a/src/main/java/com/fx/knutNotice/domain/EventNewsRepository.java
+++ b/src/main/java/com/fx/knutNotice/domain/EventNewsRepository.java
@@ -16,4 +16,6 @@ public interface EventNewsRepository extends JpaRepository<EventNews, Long> {
     @Query(value = "SELECT MIN(e.boardNumber) FROM EventNews e")
     Long findMinBoardNumber();
 
+    @Query(value = "SELECT MAX(e.nttId) FROM EventNews e")
+    Long findMaxNttId();
 }

--- a/src/main/java/com/fx/knutNotice/domain/GeneralNewsRepository.java
+++ b/src/main/java/com/fx/knutNotice/domain/GeneralNewsRepository.java
@@ -16,4 +16,6 @@ public interface GeneralNewsRepository extends JpaRepository<GeneralNews, Long> 
     @Query(value = "SELECT MIN(g.boardNumber) FROM GeneralNews g")
     Long findMinBoardNumber();
 
+    @Query(value = "SELECT MAX(g.nttId) FROM GeneralNews g")
+    Long findMaxNttId();
 }

--- a/src/main/java/com/fx/knutNotice/domain/ScholarshipNewsRepository.java
+++ b/src/main/java/com/fx/knutNotice/domain/ScholarshipNewsRepository.java
@@ -15,4 +15,7 @@ public interface ScholarshipNewsRepository extends JpaRepository<ScholarshipNews
 
     @Query(value = "SELECT MIN(s.boardNumber) FROM ScholarshipNews s")
     Long findMinBoardNumber();
+
+    @Query(value = "SELECT MAX(s.nttId) FROM ScholarshipNews s")
+    Long findMaxNttId();
 }

--- a/src/main/java/com/fx/knutNotice/service/newsUpdateService/AcademicNewsUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/newsUpdateService/AcademicNewsUpdateService.java
@@ -7,33 +7,28 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class AcademicNewsUpdateService {
 
     private final AcademicNewsRepository academicNewsRepository;
-
-    public Set<Long> extractNttIdsFromAcademicNewsList(List<AcademicNews> academicNewsList) {
-        return academicNewsList.stream()
-            .map(AcademicNews::getNttId)
-            .collect(Collectors.toSet());
-    }
+    private static long maxNttId = 0L;
 
     public void newsCheck(List<BoardDTO> newList) {
-        List<AcademicNews> oldList = academicNewsRepository.findAll();
-        Set<Long> oldNttIds = extractNttIdsFromAcademicNewsList(oldList);
+        //재시작시 사용
+        if (maxNttId == 0L) {
+            maxNttId = academicNewsRepository.findMaxNttId();
+        }
 
         //기존 데이터 false로
         academicNewsRepository.updateNewCheckToFalse();
 
         int newCount = 0;//새로운 글 개수
 
-        //새로운 데이터 저장
         for (BoardDTO boardDTO : newList) {
-            if (!oldNttIds.contains(boardDTO.getNttId())) {
+            //DB의 nttId(최신글)보다 크롤링한 nttId가 큰 경우 신규게시글로 판단
+            if (boardDTO.getNttId() > maxNttId) {
                 AcademicNews newEntity = AcademicNews.builder()
                     .nttId(boardDTO.getNttId())
                     .boardNumber(boardDTO.getBoardNumber())
@@ -49,6 +44,8 @@ public class AcademicNewsUpdateService {
                 newCount++;
             }
         }
+
+        maxNttId = newList.get(0).getNttId();
 
         //boardNumber가 가장 작은 데이터를 업데이트된 개수만큼 글 삭제
         for (int i = 0; i < newCount; i++) {

--- a/src/main/java/com/fx/knutNotice/service/newsUpdateService/EventNewsUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/newsUpdateService/EventNewsUpdateService.java
@@ -7,33 +7,28 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class EventNewsUpdateService {
 
     private final EventNewsRepository eventNewsRepository;
-
-    public Set<Long> extractNttIdsFromEventNewsList(List<EventNews> eventNewsList) {
-        return eventNewsList.stream()
-            .map(EventNews::getNttId)
-            .collect(Collectors.toSet());
-    }
+    private static long maxNttId = 0L;
 
     public void newsCheck(List<BoardDTO> newList) {
-        List<EventNews> oldList = eventNewsRepository.findAll();
-        Set<Long> oldNttIds = extractNttIdsFromEventNewsList(oldList);
+        //재시작시 사용
+        if (maxNttId == 0L) {
+            maxNttId = eventNewsRepository.findMaxNttId();
+        }
 
         //기존 데이터 false로
         eventNewsRepository.updateNewCheckToFalse();
 
         int newCount = 0;//새로운 글 개수
 
-        //새로운 데이터 저장
         for (BoardDTO boardDTO : newList) {
-            if (!oldNttIds.contains(boardDTO.getNttId())) {
+            //DB의 nttId(최신글)보다 크롤링한 nttId가 큰 경우 신규게시글로 판단
+            if (boardDTO.getNttId() > maxNttId) {
                 EventNews newEntity = EventNews.builder()
                     .nttId(boardDTO.getNttId())
                     .boardNumber(boardDTO.getBoardNumber())
@@ -49,6 +44,8 @@ public class EventNewsUpdateService {
                 newCount++;
             }
         }
+
+        maxNttId = newList.get(0).getNttId();
 
         //boardNumber가 가장 작은 데이터를 업데이트된 개수만큼 글 삭제
         for (int i = 0; i < newCount; i++) {

--- a/src/main/java/com/fx/knutNotice/service/newsUpdateService/GeneralNewsUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/newsUpdateService/GeneralNewsUpdateService.java
@@ -4,36 +4,33 @@ import com.fx.knutNotice.domain.GeneralNewsRepository;
 import com.fx.knutNotice.domain.entity.GeneralNews;
 import com.fx.knutNotice.dto.BoardDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class GeneralNewsUpdateService {
 
     private final GeneralNewsRepository generalNewsRepository;
-
-    public Set<Long> extractNttIdsFromGeneralNewsList(List<GeneralNews> generalNewsList) {
-        return generalNewsList.stream()
-            .map(GeneralNews::getNttId)
-            .collect(Collectors.toSet());
-    }
+    private static long maxNttId = 0L;
 
     public void newsCheck(List<BoardDTO> newList) {
-        List<GeneralNews> oldList = generalNewsRepository.findAll();
-        Set<Long> oldNttIds = extractNttIdsFromGeneralNewsList(oldList);
+        //재시작시 사용
+        if (maxNttId == 0L) {
+            maxNttId = generalNewsRepository.findMaxNttId();
+        }
 
         //기존 데이터 false로
         generalNewsRepository.updateNewCheckToFalse();
 
         int newCount = 0;//새로운 글 개수
 
-        //새로운 데이터 저장
         for (BoardDTO boardDTO : newList) {
-            if (!oldNttIds.contains(boardDTO.getNttId())) {
+            //DB의 nttId(최신글)보다 크롤링한 nttId가 큰 경우 신규게시글로 판단
+            if (boardDTO.getNttId() > maxNttId) {
                 GeneralNews newEntity = GeneralNews.builder()
                     .nttId(boardDTO.getNttId())
                     .boardNumber(boardDTO.getBoardNumber())
@@ -49,6 +46,8 @@ public class GeneralNewsUpdateService {
                 newCount++;
             }
         }
+
+        maxNttId = newList.get(0).getNttId();
 
         //boardNumber가 가장 작은 데이터를 업데이트된 개수만큼 글 삭제
         for (int i = 0; i < newCount; i++) {

--- a/src/main/java/com/fx/knutNotice/service/newsUpdateService/ScholarshipNewsUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/newsUpdateService/ScholarshipNewsUpdateService.java
@@ -7,34 +7,28 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ScholarshipNewsUpdateService {
 
     private final ScholarshipNewsRepository scholarshipNewsRepository;
-
-    public Set<Long> extractNttIdsFromScholarshipNewsList(
-        List<ScholarshipNews> scholarshipNewsList) {
-        return scholarshipNewsList.stream()
-            .map(ScholarshipNews::getNttId)
-            .collect(Collectors.toSet());
-    }
+    private static long maxNttId = 0L;
 
     public void newsCheck(List<BoardDTO> newList) {
-        List<ScholarshipNews> oldList = scholarshipNewsRepository.findAll();
-        Set<Long> oldNttIds = extractNttIdsFromScholarshipNewsList(oldList);
+        //재시작시 사용
+        if (maxNttId == 0L) {
+            maxNttId = scholarshipNewsRepository.findMaxNttId();
+        }
 
         //기존 데이터 false로
         scholarshipNewsRepository.updateNewCheckToFalse();
 
         int newCount = 0;//새로운 글 개수
 
-        //새로운 데이터 저장
         for (BoardDTO boardDTO : newList) {
-            if (!oldNttIds.contains(boardDTO.getNttId())) {
+            //DB의 nttId(최신글)보다 크롤링한 nttId가 큰 경우 신규게시글로 판단
+            if (boardDTO.getNttId() > maxNttId) {
                 ScholarshipNews newEntity = ScholarshipNews.builder()
                     .nttId(boardDTO.getNttId())
                     .boardNumber(boardDTO.getBoardNumber())
@@ -50,6 +44,8 @@ public class ScholarshipNewsUpdateService {
                 newCount++;
             }
         }
+
+        maxNttId = newList.get(0).getNttId();
 
         //boardNumber가 가장 작은 데이터를 업데이트된 개수만큼 글 삭제
         for (int i = 0; i < newCount; i++) {

--- a/src/test/java/com/fx/knutNotice/TestBoardData.java
+++ b/src/test/java/com/fx/knutNotice/TestBoardData.java
@@ -32,8 +32,8 @@ public class TestBoardData {
         long scholarshipCount = scholarshipNewsRepository.count();
         long academicCount = academicNewsRepository.count();
 
-        if (generalCount != 10) {
-            for (int i = 1; i <= 10; i++) {
+        if (generalCount != 100) {
+            for (int i = 1; i <= 100; i++) {
                 GeneralNews generalNews = GeneralNews.builder()
                     .nttId((long) i)
                     .boardNumber((long) i)
@@ -46,8 +46,8 @@ public class TestBoardData {
             }
         }
 
-        if (eventCount != 10) {
-            for (int i = 1; i <= 10; i++) {
+        if (eventCount != 100) {
+            for (int i = 1; i <= 100; i++) {
                 EventNews eventNews = EventNews.builder()
                     .nttId((long) i)
                     .boardNumber((long) i)
@@ -60,8 +60,8 @@ public class TestBoardData {
             }
         }
 
-        if (scholarshipCount != 10) {
-            for (int i = 1; i <= 10; i++) {
+        if (scholarshipCount != 100) {
+            for (int i = 1; i <= 100; i++) {
                 ScholarshipNews scholarshipNews = ScholarshipNews.builder()
                     .nttId((long) i)
                     .boardNumber((long) i)
@@ -74,8 +74,8 @@ public class TestBoardData {
             }
         }
 
-        if (academicCount != 10) {
-            for (int i = 1; i <= 10; i++) {
+        if (academicCount != 100) {
+            for (int i = 1; i <= 100; i++) {
                 AcademicNews academicNews = AcademicNews.builder()
                     .nttId((long) i)
                     .boardNumber((long) i)


### PR DESCRIPTION
# AS IS
```
 List<GeneralNews> oldList = generalNewsRepository.findAll();
```
`@Scheduled`이 동작할 때 매번 DB 전체를 조회해야 했음


# TO BE
```
    private static long maxNttId = 0L;
```
```
if (maxNttId == 0L) {
    maxNttId = generalNewsRepository.findMaxNttId();}
}

maxNttId = newList.get(0).getNttId();
```

`maxNttId`를 `0L`으로 초기화하고 `@Scheduled`이 동작할 때 한 번만 DB에서 `maxNttId`값을 조회. <br>

이후에는 DB를 조회하지 않고 크롤링 최신 `nttId`를 `static` 변수인 `maxNttId`에 저장