### PR TITLE
✨feat: FCM Trigger 구현

### DIFF
--- a/src/main/java/com/fx/knutNotice/dto/FcmDTO.java
+++ b/src/main/java/com/fx/knutNotice/dto/FcmDTO.java
@@ -1,21 +1,17 @@
 package com.fx.knutNotice.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class FcmDTO {
 
-    private String targetToken;
     private String title;
     private String content;
 
-    public static FcmDTO of(String targetToken, String title, String content) {
-        FcmDTO dto = new FcmDTO();
-        dto.targetToken = targetToken;
-        dto.title = title;
-        dto.content = content;
-        return dto;
-    }
 }

--- a/src/main/java/com/fx/knutNotice/service/BoardUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/BoardUpdateService.java
@@ -3,10 +3,12 @@ package com.fx.knutNotice.service;
 import com.fx.knutNotice.crawler.KnutCrawler;
 import com.fx.knutNotice.common.KnutURL;
 import com.fx.knutNotice.dto.BoardDTO;
+import com.fx.knutNotice.dto.FcmDTO;
 import com.fx.knutNotice.service.newsUpdateService.AcademicNewsUpdateService;
 import com.fx.knutNotice.service.newsUpdateService.EventNewsUpdateService;
 import com.fx.knutNotice.service.newsUpdateService.GeneralNewsUpdateService;
 import com.fx.knutNotice.service.newsUpdateService.ScholarshipNewsUpdateService;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -27,24 +29,62 @@ public class BoardUpdateService {
     private final ScholarshipNewsUpdateService scholarshipNewsUpdateService;
 
     private final KnutCrawler knutCrawler;
+    private final FcmService fcmService;
 
     @Transactional
     @Scheduled(fixedDelay = 1000 * 60 * 60)// 60분마다 실행
-    public void updateCheck() throws IOException {
+    public void updateCheck() throws IOException, FirebaseMessagingException {
         List<BoardDTO> generalNewsList = knutCrawler.crawlBoard(KnutURL.GENERAL_NEWS.URL(),
-                KnutURL.GENERAL_NEWS.articleURL());
-        generalNewsUpdateService.newsCheck(generalNewsList);
+            KnutURL.GENERAL_NEWS.articleURL());
+        List<String> updatedGeneralNewsTitle = generalNewsUpdateService.newsCheck(generalNewsList);
 
         List<BoardDTO> eventNewsList = knutCrawler.crawlBoard(KnutURL.EVENT_NEWS.URL(),
-                KnutURL.EVENT_NEWS.articleURL());
-        eventNewsUpdateService.newsCheck(eventNewsList);
+            KnutURL.EVENT_NEWS.articleURL());
+        List<String> updatedEventNewsTitle = eventNewsUpdateService.newsCheck(eventNewsList);
 
         List<BoardDTO> academicNewsList = knutCrawler.crawlBoard(KnutURL.ACADEMIC_NEWS.URL(),
-                KnutURL.ACADEMIC_NEWS.articleURL());
-        academicNewsUpdateService.newsCheck(academicNewsList);
+            KnutURL.ACADEMIC_NEWS.articleURL());
+        List<String> updatedAcademicNewsTitle = academicNewsUpdateService.newsCheck(academicNewsList);
 
         List<BoardDTO> scholarshipNewsList = knutCrawler.crawlBoard(KnutURL.SCHOLARSHIP_NEWS.URL(),
-                KnutURL.SCHOLARSHIP_NEWS.articleURL());
-        scholarshipNewsUpdateService.newsCheck(scholarshipNewsList);
+            KnutURL.SCHOLARSHIP_NEWS.articleURL());
+        List<String> updatedScholarshipNewsTitle = scholarshipNewsUpdateService.newsCheck(scholarshipNewsList);
+
+        fcmTrigger(updatedGeneralNewsTitle, updatedEventNewsTitle, updatedAcademicNewsTitle, updatedScholarshipNewsTitle);
+
+    }
+
+
+    //Front와 메시지 형식 상의 후 refactoring 진행
+    private void fcmTrigger(List<String> updatedGeneralNewsTitle,
+        List<String> updatedEventNewsTitle,
+        List<String> updatedAcademicNewsTitle,
+        List<String> updatedScholarshipNewsTitle) throws FirebaseMessagingException {
+        String updatedGeneralNewsTitles = String.join("\n", updatedGeneralNewsTitle);
+        int updatedGeneralNewsCount = updatedGeneralNewsTitle.size();
+
+        String updatedEventNewsTitles = String.join("\n", updatedEventNewsTitle);
+        int updatedEventNewsCount = updatedEventNewsTitle.size();
+
+        String updatedAcademicNewsTitles = String.join("\n", updatedAcademicNewsTitle);
+        int updatedAcademicNewsCount = updatedAcademicNewsTitle.size();
+
+        String updatedScholarshipNewsTitles = String.join("\n", updatedScholarshipNewsTitle);
+        int updatedScholarshipNewsCount = updatedScholarshipNewsTitle.size();
+
+        // FcmDTO 생성
+        FcmDTO fcmDTO = FcmDTO.builder()
+            .title("일반 뉴스 총 " + updatedGeneralNewsCount + "개 업데이트\n" +
+                "이벤트 뉴스 총 " + updatedEventNewsCount + "개 업데이트\n" +
+                "학술 뉴스 총 " + updatedAcademicNewsCount + "개 업데이트\n" +
+                "장학 뉴스 총 " + updatedScholarshipNewsCount + "개 업데이트")
+            .content(
+                "일반 뉴스 업데이트:\n" + updatedGeneralNewsTitles + "\n" +
+                    "이벤트 뉴스 업데이트:\n" + updatedEventNewsTitles + "\n" +
+                    "학술 뉴스 업데이트:\n" + updatedAcademicNewsTitles + "\n" +
+                    "장학 뉴스 업데이트:\n" + updatedScholarshipNewsTitles + "\n")
+            .build();
+
+        fcmService.sendToAllDevices(fcmDTO);
     }
 }

--- a/src/main/java/com/fx/knutNotice/service/newsUpdateService/AcademicNewsUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/newsUpdateService/AcademicNewsUpdateService.java
@@ -18,7 +18,7 @@ public class AcademicNewsUpdateService {
     public void newsCheck(List<BoardDTO> newList) {
         //재시작시 사용
         if (maxNttId == 0L) {
-            maxNttId = academicNewsRepository.findMaxNttId();
+            maxNttId = findMaxNttId();
         }
 
         //기존 데이터 false로
@@ -52,5 +52,12 @@ public class AcademicNewsUpdateService {
             Long minBoardNumber = academicNewsRepository.findMinBoardNumber();
             academicNewsRepository.deleteByBoardNumber(minBoardNumber);
         }
+
+        return titleList;
+    }
+
+    public Long findMaxNttId() {
+        Long maxNttId = academicNewsRepository.findMaxNttId();
+        return maxNttId != null ? maxNttId : 0L;
     }
 }

--- a/src/main/java/com/fx/knutNotice/service/newsUpdateService/AcademicNewsUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/newsUpdateService/AcademicNewsUpdateService.java
@@ -3,6 +3,7 @@ package com.fx.knutNotice.service.newsUpdateService;
 import com.fx.knutNotice.domain.AcademicNewsRepository;
 import com.fx.knutNotice.domain.entity.AcademicNews;
 import com.fx.knutNotice.dto.BoardDTO;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +16,10 @@ public class AcademicNewsUpdateService {
     private final AcademicNewsRepository academicNewsRepository;
     private static long maxNttId = 0L;
 
-    public void newsCheck(List<BoardDTO> newList) {
+    public List<String> newsCheck(List<BoardDTO> newList) {
+
+        List<String> titleList = new ArrayList<>();
+
         //재시작시 사용
         if (maxNttId == 0L) {
             maxNttId = findMaxNttId();
@@ -42,6 +46,9 @@ public class AcademicNewsUpdateService {
                     .build();
                 academicNewsRepository.save(newEntity);
                 newCount++;
+
+                // FCM발송을 위해 업데이트된 제목만 LIST에 추가.
+                titleList.add(boardDTO.getTitle());
             }
         }
 

--- a/src/main/java/com/fx/knutNotice/service/newsUpdateService/EventNewsUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/newsUpdateService/EventNewsUpdateService.java
@@ -3,6 +3,7 @@ package com.fx.knutNotice.service.newsUpdateService;
 import com.fx.knutNotice.domain.EventNewsRepository;
 import com.fx.knutNotice.domain.entity.EventNews;
 import com.fx.knutNotice.dto.BoardDTO;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +16,10 @@ public class EventNewsUpdateService {
     private final EventNewsRepository eventNewsRepository;
     private static long maxNttId = 0L;
 
-    public void newsCheck(List<BoardDTO> newList) {
+    public List<String> newsCheck(List<BoardDTO> newList) {
+
+        List<String> titleList = new ArrayList<>();
+
         //재시작시 사용
         if (maxNttId == 0L) {
             maxNttId = findMaxNttId();
@@ -42,6 +46,9 @@ public class EventNewsUpdateService {
                     .build();
                 eventNewsRepository.save(newEntity);
                 newCount++;
+
+                // FCM발송을 위해 업데이트된 제목만 LIST에 추가.
+                titleList.add(boardDTO.getTitle());
             }
         }
 

--- a/src/main/java/com/fx/knutNotice/service/newsUpdateService/EventNewsUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/newsUpdateService/EventNewsUpdateService.java
@@ -18,7 +18,7 @@ public class EventNewsUpdateService {
     public void newsCheck(List<BoardDTO> newList) {
         //재시작시 사용
         if (maxNttId == 0L) {
-            maxNttId = eventNewsRepository.findMaxNttId();
+            maxNttId = findMaxNttId();
         }
 
         //기존 데이터 false로
@@ -52,5 +52,12 @@ public class EventNewsUpdateService {
             Long minBoardNumber = eventNewsRepository.findMinBoardNumber();
             eventNewsRepository.deleteByBoardNumber(minBoardNumber);
         }
+
+        return titleList;
+    }
+
+    public Long findMaxNttId() {
+        Long maxNttId = eventNewsRepository.findMaxNttId();
+        return maxNttId != null ? maxNttId : 0L;
     }
 }

--- a/src/main/java/com/fx/knutNotice/service/newsUpdateService/GeneralNewsUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/newsUpdateService/GeneralNewsUpdateService.java
@@ -3,6 +3,7 @@ package com.fx.knutNotice.service.newsUpdateService;
 import com.fx.knutNotice.domain.GeneralNewsRepository;
 import com.fx.knutNotice.domain.entity.GeneralNews;
 import com.fx.knutNotice.dto.BoardDTO;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,7 +18,10 @@ public class GeneralNewsUpdateService {
     private final GeneralNewsRepository generalNewsRepository;
     private static long maxNttId = 0L;
 
-    public void newsCheck(List<BoardDTO> newList) {
+    public List<String> newsCheck(List<BoardDTO> newList) {
+
+        List<String> titleList = new ArrayList<>();
+
         //재시작시 사용
         if (maxNttId == 0L) {
             maxNttId = findMaxNttId();
@@ -44,6 +48,9 @@ public class GeneralNewsUpdateService {
                     .build();
                 generalNewsRepository.save(newEntity);
                 newCount++;
+
+                // FCM발송을 위해 업데이트된 제목만 LIST에 추가.
+                titleList.add(boardDTO.getTitle());
             }
         }
 

--- a/src/main/java/com/fx/knutNotice/service/newsUpdateService/GeneralNewsUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/newsUpdateService/GeneralNewsUpdateService.java
@@ -20,7 +20,7 @@ public class GeneralNewsUpdateService {
     public void newsCheck(List<BoardDTO> newList) {
         //재시작시 사용
         if (maxNttId == 0L) {
-            maxNttId = generalNewsRepository.findMaxNttId();
+            maxNttId = findMaxNttId();
         }
 
         //기존 데이터 false로
@@ -54,5 +54,12 @@ public class GeneralNewsUpdateService {
             Long minBoardNumber = generalNewsRepository.findMinBoardNumber();
             generalNewsRepository.deleteByBoardNumber(minBoardNumber);
         }
+
+        return titleList;
+    }
+
+    public Long findMaxNttId() {
+        Long maxNttId = generalNewsRepository.findMaxNttId();
+        return maxNttId != null ? maxNttId : 0L;
     }
 }

--- a/src/main/java/com/fx/knutNotice/service/newsUpdateService/ScholarshipNewsUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/newsUpdateService/ScholarshipNewsUpdateService.java
@@ -18,7 +18,7 @@ public class ScholarshipNewsUpdateService {
     public void newsCheck(List<BoardDTO> newList) {
         //재시작시 사용
         if (maxNttId == 0L) {
-            maxNttId = scholarshipNewsRepository.findMaxNttId();
+            maxNttId = findMaxNttId();
         }
 
         //기존 데이터 false로
@@ -52,5 +52,12 @@ public class ScholarshipNewsUpdateService {
             Long minBoardNumber = scholarshipNewsRepository.findMinBoardNumber();
             scholarshipNewsRepository.deleteByBoardNumber(minBoardNumber);
         }
+
+        return titleList;
+    }
+
+    public Long findMaxNttId() {
+        Long maxNttId = scholarshipNewsRepository.findMaxNttId();
+        return maxNttId != null ? maxNttId : 0L;
     }
 }

--- a/src/main/java/com/fx/knutNotice/service/newsUpdateService/ScholarshipNewsUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/newsUpdateService/ScholarshipNewsUpdateService.java
@@ -3,6 +3,7 @@ package com.fx.knutNotice.service.newsUpdateService;
 import com.fx.knutNotice.domain.ScholarshipNewsRepository;
 import com.fx.knutNotice.domain.entity.ScholarshipNews;
 import com.fx.knutNotice.dto.BoardDTO;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +16,10 @@ public class ScholarshipNewsUpdateService {
     private final ScholarshipNewsRepository scholarshipNewsRepository;
     private static long maxNttId = 0L;
 
-    public void newsCheck(List<BoardDTO> newList) {
+    public List<String> newsCheck(List<BoardDTO> newList) {
+
+        List<String> titleList = new ArrayList<>();
+
         //재시작시 사용
         if (maxNttId == 0L) {
             maxNttId = findMaxNttId();
@@ -42,6 +46,9 @@ public class ScholarshipNewsUpdateService {
                     .build();
                 scholarshipNewsRepository.save(newEntity);
                 newCount++;
+
+                // FCM발송을 위해 업데이트된 제목만 LIST에 추가.
+                titleList.add(boardDTO.getTitle());
             }
         }
 


### PR DESCRIPTION
# AS IS
메시지 전송을 위해 `POSTMAN` 으로 직접 요청했어야 함

# TO BE
```
    private void fcmTrigger(List<String> updatedGeneralNewsTitle,
        List<String> updatedEventNewsTitle,
        List<String> updatedAcademicNewsTitle,
        List<String> updatedScholarshipNewsTitle) throws FirebaseMessagingException {
        String updatedGeneralNewsTitles = String.join("\n", updatedGeneralNewsTitle);
```

`@Scheduled` 가 포함된 `BoardUpdateService`에서 각각의 크롤링 업데이트 작업 후 `fcmTrigger`메서드를 사용해 메시지 전송

- `Front`와 상의 후 메시지 형식 정해야 합니다. 