### PR TITLE
Refactor: 푸쉬알림 형식 변경 & 코드 리팩토링

### DIFF
--- a/src/main/java/com/fx/knutNotice/service/BoardUpdateService.java
+++ b/src/main/java/com/fx/knutNotice/service/BoardUpdateService.java
@@ -50,41 +50,9 @@ public class BoardUpdateService {
                 KnutURL.SCHOLARSHIP_NEWS.articleURL());
         List<String> updatedScholarshipNewsTitle = scholarshipNewsUpdateService.newsCheck(scholarshipNewsList);
 
-        fcmTrigger(updatedGeneralNewsTitle, updatedEventNewsTitle, updatedAcademicNewsTitle, updatedScholarshipNewsTitle);
 
-    }
+        fcmService.fcmTrigger(updatedGeneralNewsTitle, updatedEventNewsTitle, updatedAcademicNewsTitle,
+            updatedScholarshipNewsTitle);
 
-
-    //Front와 메시지 형식 상의 후 refactoring 진행
-    private void fcmTrigger(List<String> updatedGeneralNewsTitle,
-                            List<String> updatedEventNewsTitle,
-                            List<String> updatedAcademicNewsTitle,
-                            List<String> updatedScholarshipNewsTitle) throws FirebaseMessagingException {
-        String updatedGeneralNewsTitles = String.join("\n", updatedGeneralNewsTitle);
-        int updatedGeneralNewsCount = updatedGeneralNewsTitle.size();
-
-        String updatedEventNewsTitles = String.join("\n", updatedEventNewsTitle);
-        int updatedEventNewsCount = updatedEventNewsTitle.size();
-
-        String updatedAcademicNewsTitles = String.join("\n", updatedAcademicNewsTitle);
-        int updatedAcademicNewsCount = updatedAcademicNewsTitle.size();
-
-        String updatedScholarshipNewsTitles = String.join("\n", updatedScholarshipNewsTitle);
-        int updatedScholarshipNewsCount = updatedScholarshipNewsTitle.size();
-
-        // FcmDTO 생성
-        FcmDTO fcmDTO = FcmDTO.builder()
-                .title("일반 뉴스 총 " + updatedGeneralNewsCount + "개 업데이트\n" +
-                        "이벤트 뉴스 총 " + updatedEventNewsCount + "개 업데이트\n" +
-                        "학술 뉴스 총 " + updatedAcademicNewsCount + "개 업데이트\n" +
-                        "장학 뉴스 총 " + updatedScholarshipNewsCount + "개 업데이트")
-                .content(
-                        "일반 뉴스 업데이트:\n" + updatedGeneralNewsTitles + "\n" +
-                                "이벤트 뉴스 업데이트:\n" + updatedEventNewsTitles + "\n" +
-                                "학술 뉴스 업데이트:\n" + updatedAcademicNewsTitles + "\n" +
-                                "장학 뉴스 업데이트:\n" + updatedScholarshipNewsTitles + "\n")
-                .build();
-
-        fcmService.sendToAllDevices(fcmDTO);
     }
 }


### PR DESCRIPTION
# AS IS
```
        FcmDTO fcmDTO = FcmDTO.builder()
                .title("일반 뉴스 총 " + updatedGeneralNewsCount + "개 업데이트\n" +
                        "이벤트 뉴스 총 " + updatedEventNewsCount + "개 업데이트\n" +
                        "학술 뉴스 총 " + updatedAcademicNewsCount + "개 업데이트\n" +
                        "장학 뉴스 총 " + updatedScholarshipNewsCount + "개 업데이트")
                .content(
                        "일반 뉴스 업데이트:\n" + updatedGeneralNewsTitles + "\n" +
                                "이벤트 뉴스 업데이트:\n" + updatedEventNewsTitles + "\n" +
                                "학술 뉴스 업데이트:\n" + updatedAcademicNewsTitles + "\n" +
                                "장학 뉴스 업데이트:\n" + updatedScholarshipNewsTitles + "\n")
                .build();
```

한 번의 푸쉬알림으로 모든 내용을 전송했음


# TO BE
```
            FcmDTO fcmDTO = FcmDTO.builder()
                .title(category)
                .content(title)
                .build();
```

각각의 카테고리를 나누고, 제목의 개수만큼 푸쉬알림을 전송

