### PR TITLE
✨feat: Implement detail board content

### DIFF
--- a/src/main/java/com/fx/knutNotice/domain/entity/BaseNews.java
+++ b/src/main/java/com/fx/knutNotice/domain/entity/BaseNews.java
@@ -4,4 +4,15 @@ package com.fx.knutNotice.domain.entity;
  * Marker Interface.
  * 목적 : 다형성 구현용.
  */
-public interface BaseNews { }
+public interface BaseNews {
+
+    Long getNttId();
+    Long getBoardNumber();
+    String getTitle();
+    String getContentURL();
+    String getContent();
+    String getContentImage();
+    String getDepartName();
+    String getRegistrationDate();
+    String getNewCheck();
+}

--- a/src/main/java/com/fx/knutNotice/service/BoardDetailService.java
+++ b/src/main/java/com/fx/knutNotice/service/BoardDetailService.java
@@ -1,0 +1,78 @@
+package com.fx.knutNotice.service;
+
+import com.fx.knutNotice.domain.AcademicNewsRepository;
+import com.fx.knutNotice.domain.EventNewsRepository;
+import com.fx.knutNotice.domain.GeneralNewsRepository;
+import com.fx.knutNotice.domain.ScholarshipNewsRepository;
+import com.fx.knutNotice.domain.entity.AcademicNews;
+import com.fx.knutNotice.domain.entity.BaseNews;
+import com.fx.knutNotice.domain.entity.EventNews;
+import com.fx.knutNotice.domain.entity.GeneralNews;
+import com.fx.knutNotice.domain.entity.ScholarshipNews;
+import com.fx.knutNotice.dto.BoardDTO;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BoardDetailService {
+
+    private final GeneralNewsRepository generalNewsRepository;
+    private final ScholarshipNewsRepository scholarshipNewsRepository;
+    private final EventNewsRepository eventNewsRepository;
+    private final AcademicNewsRepository academicNewsRepository;
+
+    public BoardDTO showGeneralNewsDetail(Long nttId) {
+        Optional<GeneralNews> generalNewsOptional = generalNewsRepository.findById(nttId);
+        GeneralNews detail = generalNewsOptional.orElseThrow();
+
+        BoardDTO boardDTO = convertToBoardDTO(detail);
+
+        return boardDTO;
+    }
+
+    public BoardDTO showScholarshipNewsDetail(Long nttId) { //장학안내
+        Optional<ScholarshipNews> scholarshipNewsOptional = scholarshipNewsRepository.findById(nttId);
+        ScholarshipNews detail = scholarshipNewsOptional.orElseThrow();
+        BoardDTO boardDTO = convertToBoardDTO(detail);
+
+        return boardDTO;
+    }
+
+    public BoardDTO showEventNewsDetail(Long nttId) { //행사안내
+        Optional<EventNews> eventNewsOptional = eventNewsRepository.findById(nttId);
+        EventNews detail = eventNewsOptional.orElseThrow();
+        BoardDTO boardDTO = convertToBoardDTO(detail);
+
+        return boardDTO;
+    }
+
+    public BoardDTO showAcademicNewsDetail(Long nttId) { //학사공지사항
+        Optional<AcademicNews> academicNewsOptional = academicNewsRepository.findById(nttId);
+        AcademicNews detail = academicNewsOptional.orElseThrow();
+        BoardDTO boardDTO = convertToBoardDTO(detail);
+
+        return boardDTO;
+    }
+
+
+
+    private static BoardDTO convertToBoardDTO(BaseNews detail) {
+        BoardDTO boardDTO = BoardDTO.builder()
+            .nttId(detail.getNttId())
+            .boardNumber(detail.getBoardNumber())
+            .title(detail.getTitle())
+            .contentURL(detail.getContentURL())
+            .content(detail.getContent())
+            .contentImage(detail.getContentImage())
+            .departName(detail.getDepartName())
+            .registrationDate(detail.getRegistrationDate())
+            .newCheck(detail.getNewCheck())
+            .build();
+        return boardDTO;
+    }
+
+}

--- a/src/main/java/com/fx/knutNotice/service/BoardListService.java
+++ b/src/main/java/com/fx/knutNotice/service/BoardListService.java
@@ -10,11 +10,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 @Slf4j
-public class BoardService {
+public class BoardListService {
 
     private final GeneralNewsRepository generalNewsRepository;
     private final ScholarshipNewsRepository scholarshipNewsRepository;

--- a/src/main/java/com/fx/knutNotice/web/BoardDetailController.java
+++ b/src/main/java/com/fx/knutNotice/web/BoardDetailController.java
@@ -1,5 +1,6 @@
 package com.fx.knutNotice.web;
 
+import com.fx.knutNotice.common.ResponseMessage;
 import com.fx.knutNotice.dto.BoardDTO;
 import com.fx.knutNotice.service.BoardDetailService;
 import com.fx.knutNotice.web.form.ResultForm;
@@ -15,9 +16,28 @@ import org.springframework.web.bind.annotation.RestController;
 public class BoardDetailController {
 
     private final BoardDetailService boardDetailService;
+
     @GetMapping("/generalNews/{nttId}")
     public ResultForm showGeneralNewsDetail(@PathVariable Long nttId) {
         BoardDTO boardDTO = boardDetailService.showGeneralNewsDetail(nttId);
-        return ResultForm.success("성공", boardDTO);
+        return ResultForm.success(ResponseMessage.SUCCESS_GENERAL_NEWS.getDescription(), boardDTO);
+    }
+
+    @GetMapping("/scholarshipNews/{nttId}")
+    public ResultForm showScholarshipNewsDetail(@PathVariable Long nttId) {
+        BoardDTO boardDTO = boardDetailService.showScholarshipNewsDetail(nttId);
+        return ResultForm.success(ResponseMessage.SUCCESS_SCHOLARSHIP_NEWS.getDescription(), boardDTO);
+    }
+
+    @GetMapping("/eventNews/{nttId}")
+    public ResultForm showEventNewsDetail(@PathVariable Long nttId) {
+        BoardDTO boardDTO = boardDetailService.showEventNewsDetail(nttId);
+        return ResultForm.success(ResponseMessage.SUCCESS_EVENT_NEWS.getDescription(), boardDTO);
+    }
+
+    @GetMapping("/academicNews/{nttId}")
+    public ResultForm showAcademicNewsDetail(@PathVariable Long nttId) {
+        BoardDTO boardDTO = boardDetailService.showAcademicNewsDetail(nttId);
+        return ResultForm.success(ResponseMessage.SUCCESS_ACADEMIC_NEWS.getDescription(), boardDTO);
     }
 }

--- a/src/main/java/com/fx/knutNotice/web/BoardDetailController.java
+++ b/src/main/java/com/fx/knutNotice/web/BoardDetailController.java
@@ -1,0 +1,23 @@
+package com.fx.knutNotice.web;
+
+import com.fx.knutNotice.dto.BoardDTO;
+import com.fx.knutNotice.service.BoardDetailService;
+import com.fx.knutNotice.web.form.ResultForm;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "BoardDetail Controller", description = "BoardDetail Controller API")
+public class BoardDetailController {
+
+    private final BoardDetailService boardDetailService;
+    @GetMapping("/generalNews/{nttId}")
+    public ResultForm showGeneralNewsDetail(@PathVariable Long nttId) {
+        BoardDTO boardDTO = boardDetailService.showGeneralNewsDetail(nttId);
+        return ResultForm.success("성공", boardDTO);
+    }
+}

--- a/src/main/java/com/fx/knutNotice/web/BoardListController.java
+++ b/src/main/java/com/fx/knutNotice/web/BoardListController.java
@@ -2,7 +2,7 @@ package com.fx.knutNotice.web;
 
 import com.fx.knutNotice.common.ResponseMessage;
 import com.fx.knutNotice.dto.NewsListDTO;
-import com.fx.knutNotice.service.BoardService;
+import com.fx.knutNotice.service.BoardListService;
 import com.fx.knutNotice.web.form.ResultForm;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -22,9 +22,9 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "Board Controller", description = "Board Controller API")
-public class BoardController {
+public class BoardListController {
 
-    private final BoardService boardService;
+    private final BoardListService boardListService;
 
     @GetMapping("/generalNews")
     @Operation(summary = "일반소식", description = "https://www.ut.ac.kr/cop/bbs/BBSMSTR_000000000059/selectBoardList.do")
@@ -33,7 +33,7 @@ public class BoardController {
         @Parameter(description = "페이지 번호 (0부터 시작)", example = "0", in = ParameterIn.QUERY) @RequestParam(defaultValue = "0") int page,
         @Parameter(description = "한 페이지당 항목 수", example = "20", in = ParameterIn.QUERY) @RequestParam(defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("nttId").descending());
-        List<NewsListDTO> generalNewsList = boardService.showGeneralNewsList(pageable).getContent();
+        List<NewsListDTO> generalNewsList = boardListService.showGeneralNewsList(pageable).getContent();
         return ResultForm.success(ResponseMessage.SUCCESS_GENERAL_NEWS.getDescription(), generalNewsList);
     }
 
@@ -44,7 +44,7 @@ public class BoardController {
         @Parameter(description = "페이지 번호 (0부터 시작)", example = "0", in = ParameterIn.QUERY) @RequestParam(defaultValue = "0") int page,
         @Parameter(description = "한 페이지당 항목 수", example = "20", in = ParameterIn.QUERY) @RequestParam(defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("nttId").descending());
-        List<NewsListDTO> scholarshipNewsList = boardService.showScholarshipNews(pageable).getContent();
+        List<NewsListDTO> scholarshipNewsList = boardListService.showScholarshipNews(pageable).getContent();
         return ResultForm.success(ResponseMessage.SUCCESS_SCHOLARSHIP_NEWS.getDescription(), scholarshipNewsList);
     }
 
@@ -55,7 +55,7 @@ public class BoardController {
         @Parameter(description = "페이지 번호 (0부터 시작)", example = "0", in = ParameterIn.QUERY) @RequestParam(defaultValue = "0") int page,
         @Parameter(description = "한 페이지당 항목 수", example = "20", in = ParameterIn.QUERY) @RequestParam(defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("nttId").descending());
-        List<NewsListDTO> eventNewsList = boardService.showEventNews(pageable).getContent();
+        List<NewsListDTO> eventNewsList = boardListService.showEventNews(pageable).getContent();
         return ResultForm.success(ResponseMessage.SUCCESS_EVENT_NEWS.getDescription(), eventNewsList);
     }
 
@@ -66,7 +66,7 @@ public class BoardController {
         @Parameter(description = "페이지 번호 (0부터 시작)", example = "0", in = ParameterIn.QUERY) @RequestParam(defaultValue = "0") int page,
         @Parameter(description = "한 페이지당 항목 수", example = "20", in = ParameterIn.QUERY) @RequestParam(defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("nttId").descending());
-        List<NewsListDTO> academicNewsList = boardService.showAcademicNews(pageable).getContent();
+        List<NewsListDTO> academicNewsList = boardListService.showAcademicNews(pageable).getContent();
         return ResultForm.success(ResponseMessage.SUCCESS_ACADEMIC_NEWS.getDescription(), academicNewsList);
     }
 


### PR DESCRIPTION
`http://localhost:8080/xxxxxNews/{nttId}` 요청시 `nttId`에 해당하는 글 정보를 확인할 수 있다.

`nttId` : 게시글 고유 번호
`boardNumber` : 게시글 번호
`title` : 게시글 제목
`contentURL` : 게시글 URL
`content` : 게시글 내용
`contentImage` : 게시글에 포함되는 이미지
`departName` : 작성 부서명
`registrationDate` : 등록일자
`newCheck` : 새로운 글 여부 -> 추후 삭제




