### PR TITLE
✨feat: ExceptionHandler 구현

### DIFF
--- a/src/main/java/com/fx/knutNotice/common/Exception/BoardExceptionAdvice.java
+++ b/src/main/java/com/fx/knutNotice/common/Exception/BoardExceptionAdvice.java
@@ -1,0 +1,23 @@
+package com.fx.knutNotice.common.Exception;
+
+import com.fx.knutNotice.common.ResponseMessage;
+import com.fx.knutNotice.web.form.ResultForm;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class BoardExceptionAdvice {
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NotFountBoardException.class)
+    public ResultForm boardNotFoundException() {
+        log.info("게시글이 존재하지 않습니다.");
+        return ResultForm.fail(HttpStatus.NOT_FOUND.value(),
+            ResponseMessage.FAIL_NOT_FOUND_BOARD.getDescription());
+    }
+
+}

--- a/src/main/java/com/fx/knutNotice/common/Exception/NotFountBoardException.java
+++ b/src/main/java/com/fx/knutNotice/common/Exception/NotFountBoardException.java
@@ -1,0 +1,70 @@
+package com.fx.knutNotice.common.Exception;
+
+public class NotFountBoardException extends RuntimeException {
+
+    /**
+     * Constructs a new runtime exception with {@code null} as its detail message.  The cause is not
+     * initialized, and may subsequently be initialized by a call to {@link #initCause}.
+     */
+    public NotFountBoardException() {
+        super();
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message. The cause is not
+     * initialized, and may subsequently be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message. The detail message is saved for later retrieval by the
+     *                {@link #getMessage()} method.
+     */
+    public NotFountBoardException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message and cause.  <p>Note that
+     * the detail message associated with {@code cause} is <i>not</i> automatically incorporated in
+     * this runtime exception's detail message.
+     *
+     * @param message the detail message (which is saved for later retrieval by the
+     *                {@link #getMessage()} method).
+     * @param cause   the cause (which is saved for later retrieval by the {@link #getCause()}
+     *                method). (A {@code null} value is permitted, and indicates that the cause is
+     *                nonexistent or unknown.)
+     * @since 1.4
+     */
+    public NotFountBoardException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified cause and a detail message of
+     * {@code (cause==null ? null : cause.toString())} (which typically contains the class and
+     * detail message of {@code cause}).  This constructor is useful for runtime exceptions that are
+     * little more than wrappers for other throwables.
+     *
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()}
+     *              method). (A {@code null} value is permitted, and indicates that the cause is
+     *              nonexistent or unknown.)
+     * @since 1.4
+     */
+    public NotFountBoardException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message, cause, suppression
+     * enabled or disabled, and writable stack trace enabled or disabled.
+     *
+     * @param message            the detail message.
+     * @param cause              the cause.  (A {@code null} value is permitted, and indicates that
+     *                           the cause is nonexistent or unknown.)
+     * @param enableSuppression  whether or not suppression is enabled or disabled
+     * @param writableStackTrace whether or not the stack trace should be writable
+     * @since 1.7
+     */
+    protected NotFountBoardException(String message, Throwable cause, boolean enableSuppression,
+        boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/com/fx/knutNotice/common/ResponseMessage.java
+++ b/src/main/java/com/fx/knutNotice/common/ResponseMessage.java
@@ -10,7 +10,12 @@ public enum ResponseMessage {
 
 
     //MAIN PAGE
-    SUCCESS_MAIN_PAGE("메인 페이지 요청 성공");
+    SUCCESS_MAIN_PAGE("메인 페이지 요청 성공"),
+
+
+    //Exception
+    FAIL_NOT_FOUND_BOARD("존재하지 않는 게시글입니다.");
+
 
     private final String description;
 

--- a/src/main/java/com/fx/knutNotice/service/BoardDetailService.java
+++ b/src/main/java/com/fx/knutNotice/service/BoardDetailService.java
@@ -1,5 +1,7 @@
 package com.fx.knutNotice.service;
 
+import com.fx.knutNotice.common.Exception.BoardExceptionAdvice;
+import com.fx.knutNotice.common.Exception.NotFountBoardException;
 import com.fx.knutNotice.domain.AcademicNewsRepository;
 import com.fx.knutNotice.domain.EventNewsRepository;
 import com.fx.knutNotice.domain.GeneralNewsRepository;
@@ -27,7 +29,7 @@ public class BoardDetailService {
 
     public BoardDTO showGeneralNewsDetail(Long nttId) {
         Optional<GeneralNews> generalNewsOptional = generalNewsRepository.findById(nttId);
-        GeneralNews detail = generalNewsOptional.orElseThrow();
+        GeneralNews detail = generalNewsOptional.orElseThrow(NotFountBoardException::new);
 
         BoardDTO boardDTO = convertToBoardDTO(detail);
 
@@ -36,7 +38,7 @@ public class BoardDetailService {
 
     public BoardDTO showScholarshipNewsDetail(Long nttId) { //장학안내
         Optional<ScholarshipNews> scholarshipNewsOptional = scholarshipNewsRepository.findById(nttId);
-        ScholarshipNews detail = scholarshipNewsOptional.orElseThrow();
+        ScholarshipNews detail = scholarshipNewsOptional.orElseThrow(NotFountBoardException::new);
         BoardDTO boardDTO = convertToBoardDTO(detail);
 
         return boardDTO;
@@ -44,7 +46,7 @@ public class BoardDetailService {
 
     public BoardDTO showEventNewsDetail(Long nttId) { //행사안내
         Optional<EventNews> eventNewsOptional = eventNewsRepository.findById(nttId);
-        EventNews detail = eventNewsOptional.orElseThrow();
+        EventNews detail = eventNewsOptional.orElseThrow(NotFountBoardException::new);
         BoardDTO boardDTO = convertToBoardDTO(detail);
 
         return boardDTO;
@@ -52,7 +54,7 @@ public class BoardDetailService {
 
     public BoardDTO showAcademicNewsDetail(Long nttId) { //학사공지사항
         Optional<AcademicNews> academicNewsOptional = academicNewsRepository.findById(nttId);
-        AcademicNews detail = academicNewsOptional.orElseThrow();
+        AcademicNews detail = academicNewsOptional.orElseThrow(NotFountBoardException::new);
         BoardDTO boardDTO = convertToBoardDTO(detail);
 
         return boardDTO;


### PR DESCRIPTION
잘못된 `nttId`로 게시글을 조회하려는 경우 `Spring`의 `ExceptionHandler`에서 예외처리를 담당한다.

```
@RestControllerAdvice
@Slf4j
public class BoardExceptionAdvice {

    @ResponseStatus(HttpStatus.NOT_FOUND)
    @ExceptionHandler(NotFountBoardException.class)
    public ResultForm boardNotFoundException() {
        log.info("게시글이 존재하지 않습니다.");
        return ResultForm.fail(HttpStatus.NOT_FOUND.value(),
            ResponseMessage.FAIL_NOT_FOUND_BOARD.getDescription());
    }

}
```

```
{
    "statusCode": 404,
    "message": "존재하지 않는 게시글입니다.",
    "data": null
}
```

issue : #26