### PR TITLE
♻️refactor: 게시글 리스트 요청 방식 변경

### DIFF
--- a/src/main/java/com/fx/knutNotice/domain/BaseNewsRepository.java
+++ b/src/main/java/com/fx/knutNotice/domain/BaseNewsRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.query.Param;
 
 
 /**
@@ -34,7 +35,18 @@ public interface BaseNewsRepository<T, ID> extends JpaRepository<T, ID> {
         + " FROM #{#entityName} a ORDER BY a.nttId DESC LIMIT 3")
     List<NewsListDTO> findRecent3Title();
 
-    @Query(value ="SELECT a.nttId as nttId, a.title as title, a.departName as departName, a.registrationDate as registrationDate"
-        + " FROM #{#entityName} a")
-    Page<NewsListDTO> findPaginationList(Pageable pageable);
+    @Query(value = "SELECT a.nttId as nttId, a.boardNumber as boardNumber, a.title as title, a.departName as departName, a.registrationDate as registrationDate"
+        + " FROM #{#entityName} a"
+        + " WHERE a.boardNumber < :startBoardNumber"
+        + " ORDER BY a.boardNumber DESC")
+    List<NewsListDTO> findPaginationList(@Param("startBoardNumber") Long startBoardNumber, Pageable pageable);
+
+    /**
+     * 뉴스 리스트 첫 요청시 반환되는 메서드
+     * 상위 20개의 리스트만 반환
+     */
+    @Query(value = "SELECT a.nttId as nttId, a.boardNumber as boardNumber, a.title as title, a.departName as departName, a.registrationDate as registrationDate"
+        + " FROM #{#entityName} a"
+        + " ORDER BY a.boardNumber DESC")
+    List<NewsListDTO> find20RecentNews(Pageable pageable);
 }

--- a/src/main/java/com/fx/knutNotice/dto/NewsListDTO.java
+++ b/src/main/java/com/fx/knutNotice/dto/NewsListDTO.java
@@ -4,6 +4,8 @@ public interface NewsListDTO {
 
     Long getNttId();
 
+    Long getBoardNumber();
+
     String getTitle();
 
     String getDepartName();

--- a/src/main/java/com/fx/knutNotice/service/BoardListService.java
+++ b/src/main/java/com/fx/knutNotice/service/BoardListService.java
@@ -1,14 +1,18 @@
 package com.fx.knutNotice.service;
 
 import com.fx.knutNotice.domain.AcademicNewsRepository;
+import com.fx.knutNotice.domain.BaseNewsRepository;
 import com.fx.knutNotice.domain.EventNewsRepository;
 import com.fx.knutNotice.domain.GeneralNewsRepository;
 import com.fx.knutNotice.domain.ScholarshipNewsRepository;
 import com.fx.knutNotice.dto.NewsListDTO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,25 +27,32 @@ public class BoardListService {
     private final EventNewsRepository eventNewsRepository;
     private final AcademicNewsRepository academicNewsRepository;
 
-    public Page<NewsListDTO> showGeneralNewsList(Pageable pageable) { //일반공지
-        Page<NewsListDTO> generalNewsPageList = generalNewsRepository.findPaginationList(pageable);
-        return generalNewsPageList;
+    public List<NewsListDTO> showGeneralNewsList(Long startBoardNumber, int size) {
+        return getNewsList(generalNewsRepository, startBoardNumber, size);
     }
 
-    public Page<NewsListDTO> showScholarshipNews(Pageable pageable) { //장학안내
-        Page<NewsListDTO> scholarshipNewsPageList = scholarshipNewsRepository.findPaginationList(pageable);
-        return scholarshipNewsPageList;
+    public List<NewsListDTO> showScholarshipNews(Long startBoardNumber, int size) {
+        return getNewsList(scholarshipNewsRepository, startBoardNumber, size);
     }
 
-    public Page<NewsListDTO> showEventNews(Pageable pageable) { //행사안내
-        Page<NewsListDTO> eventNewsPageList = eventNewsRepository.findPaginationList(pageable);
-        return eventNewsPageList;
+    public List<NewsListDTO> showEventNews(Long startBoardNumber, int size) {
+        return getNewsList(eventNewsRepository, startBoardNumber, size);
     }
 
-    public Page<NewsListDTO> showAcademicNews(Pageable pageable) { //학사공지사항
-        Page<NewsListDTO> academicNewsPageList = academicNewsRepository.findPaginationList(pageable);
-        return academicNewsPageList;
+    public List<NewsListDTO> showAcademicNews(Long startBoardNumber, int size) {
+        return getNewsList(academicNewsRepository, startBoardNumber, size);
     }
 
+    private List<NewsListDTO> getNewsList(BaseNewsRepository repository, Long startBoardNumber, int size) {
 
+        // startBoardNumber가 null일 경우 최근 게시물부터 20개를 가져옴
+        if (startBoardNumber == null)
+            return repository.find20RecentNews(
+                PageRequest.of(0, size, Sort.by("boardNumber").descending()));
+
+
+        return repository.findPaginationList(startBoardNumber,
+            PageRequest.of(0, size, Sort.by("boardNumber").descending()));
+
+    }
 }

--- a/src/main/java/com/fx/knutNotice/web/BoardListController.java
+++ b/src/main/java/com/fx/knutNotice/web/BoardListController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -30,10 +31,9 @@ public class BoardListController {
     @Operation(summary = "일반소식", description = "https://www.ut.ac.kr/cop/bbs/BBSMSTR_000000000059/selectBoardList.do")
     @ApiResponse(responseCode = "200", description = "일반소식 요청 성공")
     public ResultForm showGeneralNews(
-        @Parameter(description = "페이지 번호 (0부터 시작)", example = "0", in = ParameterIn.QUERY) @RequestParam(defaultValue = "0") int page,
+        @Parameter(description = "마지막 순번", example = "최초 요청시 값X", in = ParameterIn.QUERY) @RequestParam(required = false) Long startBoardNumber,
         @Parameter(description = "한 페이지당 항목 수", example = "20", in = ParameterIn.QUERY) @RequestParam(defaultValue = "20") int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("nttId").descending());
-        List<NewsListDTO> generalNewsList = boardListService.showGeneralNewsList(pageable).getContent();
+        List<NewsListDTO> generalNewsList = boardListService.showGeneralNewsList(startBoardNumber, size);
         return ResultForm.success(ResponseMessage.SUCCESS_GENERAL_NEWS.getDescription(), generalNewsList);
     }
 
@@ -41,10 +41,9 @@ public class BoardListController {
     @Operation(summary = "장학안내", description = "https://www.ut.ac.kr/cop/bbs/BBSMSTR_000000000060/selectBoardList.do")
     @ApiResponse(responseCode = "200", description = "장학안내 요청 성공")
     public ResultForm showScholarshipNews(
-        @Parameter(description = "페이지 번호 (0부터 시작)", example = "0", in = ParameterIn.QUERY) @RequestParam(defaultValue = "0") int page,
+        @Parameter(description = "마지막 순번", example = "0", in = ParameterIn.QUERY) @RequestParam(required = false) Long startBoardNumber,
         @Parameter(description = "한 페이지당 항목 수", example = "20", in = ParameterIn.QUERY) @RequestParam(defaultValue = "20") int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("nttId").descending());
-        List<NewsListDTO> scholarshipNewsList = boardListService.showScholarshipNews(pageable).getContent();
+        List<NewsListDTO> scholarshipNewsList = boardListService.showScholarshipNews(startBoardNumber, size);
         return ResultForm.success(ResponseMessage.SUCCESS_SCHOLARSHIP_NEWS.getDescription(), scholarshipNewsList);
     }
 
@@ -52,10 +51,9 @@ public class BoardListController {
     @Operation(summary = "행사안내", description = "https://www.ut.ac.kr/cop/bbs/BBSMSTR_000000000061/selectBoardList.do")
     @ApiResponse(responseCode = "200", description = "행사안내 요청 성공")
     public ResultForm showEventNews(
-        @Parameter(description = "페이지 번호 (0부터 시작)", example = "0", in = ParameterIn.QUERY) @RequestParam(defaultValue = "0") int page,
+        @Parameter(description = "마지막 순번", example = "0", in = ParameterIn.QUERY) @RequestParam(required = false) Long startBoardNumber,
         @Parameter(description = "한 페이지당 항목 수", example = "20", in = ParameterIn.QUERY) @RequestParam(defaultValue = "20") int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("nttId").descending());
-        List<NewsListDTO> eventNewsList = boardListService.showEventNews(pageable).getContent();
+        List<NewsListDTO> eventNewsList = boardListService.showEventNews(startBoardNumber, size);
         return ResultForm.success(ResponseMessage.SUCCESS_EVENT_NEWS.getDescription(), eventNewsList);
     }
 
@@ -63,10 +61,9 @@ public class BoardListController {
     @Operation(summary = "학사공지사항", description = "https://www.ut.ac.kr/cop/bbs/BBSMSTR_000000000055/selectBoardList.do")
     @ApiResponse(responseCode = "200", description = "학사공지사항 요청 성공")
     public ResultForm showAcademicNews(
-        @Parameter(description = "페이지 번호 (0부터 시작)", example = "0", in = ParameterIn.QUERY) @RequestParam(defaultValue = "0") int page,
+        @Parameter(description = "마지막 순번", example = "0", in = ParameterIn.QUERY) @RequestParam(required = false) Long startBoardNumber,
         @Parameter(description = "한 페이지당 항목 수", example = "20", in = ParameterIn.QUERY) @RequestParam(defaultValue = "20") int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("nttId").descending());
-        List<NewsListDTO> academicNewsList = boardListService.showAcademicNews(pageable).getContent();
+        List<NewsListDTO> academicNewsList = boardListService.showAcademicNews(startBoardNumber, size);
         return ResultForm.success(ResponseMessage.SUCCESS_ACADEMIC_NEWS.getDescription(), academicNewsList);
     }
 

--- a/src/test/java/com/fx/knutNotice/TestBoardData.java
+++ b/src/test/java/com/fx/knutNotice/TestBoardData.java
@@ -37,9 +37,9 @@ public class TestBoardData {
                 GeneralNews generalNews = GeneralNews.builder()
                     .nttId((long) i)
                     .boardNumber((long) i)
-                    .title(i + "번 째 게시글 제목")
+                    .title(i + "게시글을 확인할 수 없습니다.")
                     .contentURL(i + "번 째 URL")
-                    .content(i + "번 째 글내용")
+                    .content(i + "게시글을 확인할 수 없습니다.")
                     .newCheck("true")
                     .build();
                 generalNewsRepository.save(generalNews);
@@ -51,9 +51,9 @@ public class TestBoardData {
                 EventNews eventNews = EventNews.builder()
                     .nttId((long) i)
                     .boardNumber((long) i)
-                    .title(i + "번 째 게시글 제목")
+                    .title(i + "게시글을 확인할 수 없습니다.")
                     .contentURL(i + "번 째 URL")
-                    .content(i + "번 째 글내용")
+                    .content(i + "게시글을 확인할 수 없습니다.")
                     .newCheck("true")
                     .build();
                 eventNewsRepository.save(eventNews);
@@ -65,9 +65,9 @@ public class TestBoardData {
                 ScholarshipNews scholarshipNews = ScholarshipNews.builder()
                     .nttId((long) i)
                     .boardNumber((long) i)
-                    .title(i + "번 째 게시글 제목")
+                    .title(i + "게시글을 확인할 수 없습니다.")
                     .contentURL(i + "번 째 URL")
-                    .content(i + "번 째 글내용")
+                    .content(i + "게시글을 확인할 수 없습니다.")
                     .newCheck("true")
                     .build();
                 scholarshipNewsRepository.save(scholarshipNews);
@@ -79,9 +79,9 @@ public class TestBoardData {
                 AcademicNews academicNews = AcademicNews.builder()
                     .nttId((long) i)
                     .boardNumber((long) i)
-                    .title(i + "번 째 게시글 제목")
+                    .title(i + "게시글을 확인할 수 없습니다.")
                     .contentURL(i + "번 째 URL")
-                    .content(i + "번 째 글내용")
+                    .content(i + "게시글을 확인할 수 없습니다.")
                     .newCheck("true")
                     .build();
                 academicNewsRepository.save(academicNews);


### PR DESCRIPTION
# AS IS

`/generalNews` or `/generalNews?page=0` 요청시 상위 20개의 게시글 리스트를 반환했음
`page`의 값이 증가할 때마다 다음 20개의 리스트를 반환.

- 🤔문제점
   - 게시글이 스크롤되는 도중 크롤링으로 인한 업데이트 발생시 중복 데이터 발생


# TO BE 
- 🪛해결 
    - `/generalNews` 최초 요청시 상위 20개의 글을 반환
    - 최초 요청 후 마지막 `boardNumber`값을 파라미터로 전달 (`startBoradNumber=마지막번호`)
        -  ex) 최초 요청 후 가장 마지막 글이 50번인 게시글일 때 `/generalNews?startNumber=50` 요청 
        - 51부터 하위 20개의 글이 반환됨
    


   ```
       private List<NewsListDTO> getNewsList(BaseNewsRepository repository, Long startBoardNumber, int size) {

        // startBoardNumber가 null일 경우 최근 게시물부터 20개를 가져옴
        if (startBoardNumber == null)
            return repository.find20RecentNews(
                PageRequest.of(0, size, Sort.by("boardNumber").descending()));

        return repository.findPaginationList(startBoardNumber,
            PageRequest.of(0, size, Sort.by("boardNumber").descending()));
    }
```