### PR TITLE
♻️refactor: JSON 필드 추가 및 제거, contentImage 처리 방식 변경

### DIFF
--- a/src/main/java/com/fx/knutNotice/crawler/KnutCrawler.java
+++ b/src/main/java/com/fx/knutNotice/crawler/KnutCrawler.java
@@ -45,6 +45,10 @@ public class KnutCrawler {
                 String detailContent = articleContent.html();
                 String contentImage = articleContent.select("div.bbs_detail_content img").attr("src"); //이미지 추출
 
+                // contentImage가 빈 문자열이면 null로 설정
+                if (contentImage.isEmpty()) {
+                    contentImage = null;
+                }
 
                 boardDTOList.add(BoardDTO.builder()
                         .nttId(Long.valueOf(nttId))

--- a/src/main/java/com/fx/knutNotice/domain/BaseNewsRepository.java
+++ b/src/main/java/com/fx/knutNotice/domain/BaseNewsRepository.java
@@ -30,9 +30,10 @@ public interface BaseNewsRepository<T, ID> extends JpaRepository<T, ID> {
     @Query(value = "SELECT MAX(a.nttId) FROM #{#entityName} a")
     Long findMaxNttId();
 
-    @Query(value ="SELECT a.nttId as nttId, a.title as title, a.departName as departName, a.registrationDate as registrationDate"
+    @Query(value ="SELECT a.nttId as nttId, a.title as title, a.departName as departName,"
+        + " a.registrationDate as registrationDate, a.contentURL as contentURL"
         + " FROM #{#entityName} a ORDER BY a.nttId DESC LIMIT 3")
-    List<NewsListDTO> findRecent3Title();
+    List<NewsMainDTO> findRecent3Title();
 
     @Query(value = "SELECT a.nttId as nttId, a.boardNumber as boardNumber, a.title as title,"
         + " a.departName as departName, a.registrationDate as registrationDate, a.contentImage as contentImage"

--- a/src/main/java/com/fx/knutNotice/domain/BaseNewsRepository.java
+++ b/src/main/java/com/fx/knutNotice/domain/BaseNewsRepository.java
@@ -1,6 +1,7 @@
 package com.fx.knutNotice.domain;
 
 import com.fx.knutNotice.dto.NewsListDTO;
+import com.fx.knutNotice.dto.NewsMainDTO;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -36,7 +37,8 @@ public interface BaseNewsRepository<T, ID> extends JpaRepository<T, ID> {
     List<NewsMainDTO> findRecent3Title();
 
     @Query(value = "SELECT a.nttId as nttId, a.boardNumber as boardNumber, a.title as title,"
-        + " a.departName as departName, a.registrationDate as registrationDate, a.contentImage as contentImage"
+        + " a.departName as departName, a.registrationDate as registrationDate,"
+        + " a.contentImage as contentImage, a.contentURL as contentURL"
         + " FROM #{#entityName} a"
         + " WHERE a.boardNumber < :startBoardNumber"
         + " ORDER BY a.boardNumber DESC")
@@ -47,7 +49,8 @@ public interface BaseNewsRepository<T, ID> extends JpaRepository<T, ID> {
      * 상위 20개의 리스트만 반환
      */
     @Query(value = "SELECT a.nttId as nttId, a.boardNumber as boardNumber, a.title as title,"
-        + " a.departName as departName, a.registrationDate as registrationDate, a.contentImage as contentImage"
+        + " a.departName as departName, a.registrationDate as registrationDate,"
+        + " a.contentImage as contentImage, a.contentURL as contentURL"
         + " FROM #{#entityName} a"
         + " ORDER BY a.boardNumber DESC")
     List<NewsListDTO> find20RecentNews(Pageable pageable);

--- a/src/main/java/com/fx/knutNotice/dto/NewsListDTO.java
+++ b/src/main/java/com/fx/knutNotice/dto/NewsListDTO.java
@@ -14,4 +14,6 @@ public interface NewsListDTO {
 
     String getContentImage();
 
+    String getContentURL();
+
 }

--- a/src/main/java/com/fx/knutNotice/dto/NewsMainDTO.java
+++ b/src/main/java/com/fx/knutNotice/dto/NewsMainDTO.java
@@ -1,0 +1,15 @@
+package com.fx.knutNotice.dto;
+
+public interface NewsMainDTO {
+
+    Long getNttId();
+
+    String getTitle();
+
+    String getDepartName();
+
+    String getRegistrationDate();
+
+    String getContentURL();
+
+}

--- a/src/main/java/com/fx/knutNotice/service/MainHomeService.java
+++ b/src/main/java/com/fx/knutNotice/service/MainHomeService.java
@@ -2,6 +2,7 @@ package com.fx.knutNotice.service;
 
 import com.fx.knutNotice.domain.*;
 import com.fx.knutNotice.dto.NewsListDTO;
+import com.fx.knutNotice.dto.NewsMainDTO;
 import com.fx.knutNotice.web.form.ResponseForm.MainForm;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,10 +23,10 @@ public class MainHomeService {
 
     public MainForm showMainTopThreeTitle() {
 
-        List<NewsListDTO> generalNewsRecent3Title = generalNewsRepository.findRecent3Title();
-        List<NewsListDTO> scholarshipNewsRecent3Title = scholarshipNewsRepository.findRecent3Title();
-        List<NewsListDTO> eventNewsRecent3Title = eventNewsRepository.findRecent3Title();
-        List<NewsListDTO> academicNewsRecent3Title = academicNewsRepository.findRecent3Title();
+        List<NewsMainDTO> generalNewsRecent3Title = generalNewsRepository.findRecent3Title();
+        List<NewsMainDTO> scholarshipNewsRecent3Title = scholarshipNewsRepository.findRecent3Title();
+        List<NewsMainDTO> eventNewsRecent3Title = eventNewsRepository.findRecent3Title();
+        List<NewsMainDTO> academicNewsRecent3Title = academicNewsRepository.findRecent3Title();
 
         return new MainForm(generalNewsRecent3Title, scholarshipNewsRecent3Title,
             eventNewsRecent3Title, academicNewsRecent3Title);

--- a/src/main/java/com/fx/knutNotice/web/form/ResponseForm/MainForm.java
+++ b/src/main/java/com/fx/knutNotice/web/form/ResponseForm/MainForm.java
@@ -1,6 +1,7 @@
 package com.fx.knutNotice.web.form.ResponseForm;
 
 import com.fx.knutNotice.dto.NewsListDTO;
+import com.fx.knutNotice.dto.NewsMainDTO;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -9,9 +10,9 @@ import lombok.Getter;
 @Getter
 public class MainForm {
 
-    private List<NewsListDTO> generalNewsTopThreeTitle;
-    private List<NewsListDTO> scholarshipNewsTopThreeTitle;
-    private List<NewsListDTO> eventNewsTopThreeTitle;
-    private List<NewsListDTO> academicNewsTopThreeTitle;
+    private List<NewsMainDTO> generalNewsTopThreeTitle;
+    private List<NewsMainDTO> scholarshipNewsTopThreeTitle;
+    private List<NewsMainDTO> eventNewsTopThreeTitle;
+    private List<NewsMainDTO> academicNewsTopThreeTitle;
 
 }


### PR DESCRIPTION
# 1. 🪛contentImage 처리 방식 변경 
**KnutCrawler**
이미지가 존재하지 않는 경우 공백문자가 아닌 `null`로 저장
```

                // contentImage가 빈 문자열이면 null로 설정
                if (contentImage.isEmpty()) {
                    contentImage = null;
                }

                boardDTOList.add(BoardDTO.builder()
                        .nttId(Long.valueOf(nttId))
                        .boardNumber(Long.valueOf(boardNumber))
                        .title(title)
                        .contentURL(contentURL)
                        .content(detailContent)
                        .contentImage(contentImage)
                        .departName(departName)
                        .registrationDate(registrationDate)
                        .build());
            
```

# 2.🪛Main 응답에 불필요한 필드 제거
- 문제 : 기존에는 `NewsListDTO`를 공유하여 사용 -> 불필요한 필드가 포함되는 문제 발생 
- 헤결 : `NewsMainDTO` 클래스를 생성하여 분리 

# 🪛페이지네이션 및 Main 응답에 contentURL 필드 추가
```
    String getContentURL();
```
