### PR TITLE
♻️refactor: Crawling 중복 코드 제거 & 모듈 명칭 변경 및 재분리 & StopWatch import문 삭제

### DIFF
--- a/src/main/java/com/fx/knutNotice/dto/BoardDTO.java
+++ b/src/main/java/com/fx/knutNotice/dto/BoardDTO.java
@@ -17,4 +17,5 @@ public class BoardDTO {
     private String contentImage;
     private String departName;
     private String registrationDate;
+    private byte boardType;
 }

--- a/src/main/java/com/fx/knutNotice/factory/ServiceFactory.java
+++ b/src/main/java/com/fx/knutNotice/factory/ServiceFactory.java
@@ -16,7 +16,6 @@ public class ServiceFactory {
     private final EventNewsUpdateService eventNewsUpdateService;
     private final ScholarshipNewsUpdateService scholarshipNewsUpdateService;
     public BaseNewsService getService(final byte type) {
-        // 타입에 따라 줘버리자
         switch (type) {
             case 0:
                 return generalNewsUpdateService;

--- a/src/main/java/com/fx/knutNotice/worker/BoardCrawlingWorker.java
+++ b/src/main/java/com/fx/knutNotice/worker/BoardCrawlingWorker.java
@@ -5,6 +5,8 @@ import com.fx.knutNotice.common.KnutURL;
 import com.fx.knutNotice.dto.BoardDTO;
 import com.fx.knutNotice.factory.KnutURLFactory;
 import com.google.firebase.messaging.FirebaseMessagingException;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
@@ -14,6 +16,7 @@ import org.jsoup.select.Elements;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StopWatch;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -25,149 +28,123 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class BoardCrawlingWorker {
+    // 서버의 첫 실행 여부
+    private static boolean boot = true;
+
+    // 보드 유형 개수
     private static final byte boardLength = 4;
+
     // 첫 게시글의 제목을 담아둘 배열 변수
     private static String[] boardTitles = new String[boardLength];
-    // 서버의 첫 실행 여부
-    private static boolean boot = false;
+
+
     private final BoardUpdateWorker boardUpdateWorker;
 
+
+    @Getter
+    @Builder
+    static class HtmlDocDTO {
+        private String boardURL;
+        private String articleURL;
+        private byte boardType;
+    }
 
 
     @Transactional
 //    @Scheduled(cron = "0 0 8-20 * * MON-FRI") //월요일부터 금요일까지 매 시간 정각마다 실행되지만 8시부터 20시까지만 실행
     @Scheduled(fixedDelay = 1000*30) //월요일부터 금요일까지 매 시간 정각마다 실행되지만 8시부터 20시까지만 실행
-    public void crawlBoard() throws IOException, FirebaseMessagingException {
-        if(boot == false) {
-            log.info("[Server] 처음 서버 크롤링 시작");
-            deliverTitlesToWorker(List.of(
-                    getBoardFromKNUT(setBoardUrls(KnutURL.GENERAL_NEWS.type())),
-                    getBoardFromKNUT(setBoardUrls(KnutURL.SCHOLARSHIP_NEWS.type())),
-                    getBoardFromKNUT(setBoardUrls(KnutURL.EVENT_NEWS.type())),
-                    getBoardFromKNUT(setBoardUrls(KnutURL.ACADEMIC_NEWS.type()))
-            ));
-            log.info("[Server] 처음 서버 크롤링 종료");
-            boot = true;
+    public void scheduledBoardCrawl() throws IOException, FirebaseMessagingException {
 
-        } else {
-            log.info("[Server] 서버 크롤링 시작");
-            deliverTitlesToWorker(List.of(
-                getBoardFromKNUT(setBoardUrls(KnutURL.GENERAL_NEWS.type())),
-                getBoardFromKNUT(setBoardUrls(KnutURL.SCHOLARSHIP_NEWS.type())),
-                getBoardFromKNUT(setBoardUrls(KnutURL.EVENT_NEWS.type())),
-                getBoardFromKNUT(setBoardUrls(KnutURL.ACADEMIC_NEWS.type()))
-            ));
-            log.info("[Server] 서버 크롤링 종료");
+        doCrawling();
+
+        if (boot) {
+            boot = false;
         }
     }
 
+    /**
+     * Crawling Method 통합.
+     */
+    private void doCrawling() throws FirebaseMessagingException, IOException {
+        deliverTitlesToWorker(List.of(
+            getBoardFromKNUT(setBoardUrls(KnutURL.GENERAL_NEWS.type())),
+            getBoardFromKNUT(setBoardUrls(KnutURL.SCHOLARSHIP_NEWS.type())),
+            getBoardFromKNUT(setBoardUrls(KnutURL.EVENT_NEWS.type())),
+            getBoardFromKNUT(setBoardUrls(KnutURL.ACADEMIC_NEWS.type()))
+        ));
 
+    }
 
+    private List<BoardDTO> getBoardFromKNUT(List<Serializable> boardUrls) throws IOException{
+        HtmlDocDTO htmlDocDTO = HtmlDocDTO.builder()
+                .boardURL((String)boardUrls.get(0))
+                .articleURL((String)boardUrls.get(1))
+                .boardType((byte)boardUrls.get(2))
+                .build();
 
-    private List<BoardDTO> getBoardFromKNUT(List<Serializable> boardUrls) throws IOException {
-        // init URL & data
-        String boardURL = (String)boardUrls.get(0);
-        String articleURL = (String)boardUrls.get(1);
-        byte boardType = (byte)boardUrls.get(2);
+        List<BoardDTO> result = searchDocumentation(getHtmlDocumentation(htmlDocDTO));
+        return result;
+    }
+    
+    private List<BoardDTO> searchDocumentation(List<Object> crawledData) throws IOException {
+        boolean checkFirstBoardTitle = true;
+        Elements contents = (Elements) crawledData.get(0);
+        HtmlDocDTO htmlDocDTO = (HtmlDocDTO) crawledData.get(1);
         List<BoardDTO> boardDTOList = new ArrayList<>();
 
+        for (Element content : contents) {
+            String nttId = content.select("input[type=hidden][name=nttId]").val();
+            // [공지]가 아닌 게시글이라면
+            if(!nttId.isEmpty()) {
+                // 게시글의 제목을 추출.
+                String newTitle = content.select("td.left > div > div > form > input[type=submit]").val();
 
-        // get HTML document
-        Document document = Jsoup.connect(boardURL).get();
-        Elements contents = document.select("tbody > tr");
 
-        // start crawling
-        boolean checkFirstBoardTitle = true;
-        if(boot == false) {
-            crawlAtServerIsFirst(contents, checkFirstBoardTitle, boardType, articleURL, boardDTOList);
-        } else {
-            crawlAtServerIsNotFirst(contents, checkFirstBoardTitle, boardType, articleURL, boardDTOList);
+                // 서버가 처음 실행 중인 상태라면
+                if(boot) {
+                    // 첫번째 게시글의 제목을 boarTitles 저장.
+                    if(checkFirstBoardTitle) {
+                        boardTitles[htmlDocDTO.getBoardType()] = newTitle;
+                        checkFirstBoardTitle = false;
+
+                    }
+                } else {
+                    // 서버가 시작중인 상태가 아니고, 이미지가 없다면, 읽어올 필요가 없으므로 break
+                    if(extractImageTag(content)) break;
+
+                    if(checkFirstBoardTitle) {
+                        // 'N' 이미지 태그가 있고, 기존 첫 게시글의 제목과 새로 가져온 게시글이 같다면 종료
+                        if(boardTitles[htmlDocDTO.boardType].equals(newTitle)) {
+                            log.info("[Crawling-Worker] 'N' 이미지 태그가 있지만, 기존 첫 게시글의 제목과 새로 가져온 게시물이 같다면 종료");
+                            break;
+                        }
+                        // 'N' 이미지 태그가 있고, 기존 첫 게시글의 제목과 새로 가져온 게시글이 같지 않다면
+                        boardTitles[htmlDocDTO.getBoardType()] = newTitle;
+                        checkFirstBoardTitle = false;
+                    }
+                }
+                // 1. 서버가 처음 실행 될 때
+                // 2. 'N' 이미지 태그가 있고, 기존 첫 게시글의 제목과 새로 가져온 게시글이 같지 않다면
+                // 3. 'N' 이미지 태그가 있고, 기존 첫 게시글의 제목과 새로 가져온 게시글이 같지 않을때, 하위 게시글을 전부 가지고 옴.
+                getNewBoard(content, htmlDocDTO.getArticleURL(), nttId, boardDTOList);
+            }
         }
         return boardDTOList;
     }
 
-    /**
-     * 서버가 처음 실행될 때, 실행되는 크롤링
-     */
-    /**
-     * 크롤링한 각 보드 유형의 '첫 번째' 게시글의 제목을 boardTitles 배열에 저장합니다.
-     * 첫 번째 게시글을 포함해서 하위 10개의 게시글을 모두 업데이트합니다.
-     *
-     */
+    public List<Object> getHtmlDocumentation(final HtmlDocDTO htmlDocDTO) throws IOException{
+        // get HTML document
+        Document document = Jsoup.connect(htmlDocDTO.getBoardURL()).get();
+        Elements contents = document.select("tbody > tr");
 
-    private void crawlAtServerIsFirst(Elements contents, boolean checkFirstBoardTitle, byte boardType, String articleURL, List<BoardDTO> boardDTOList) throws IOException {
-        for (Element content : contents) {
-            String nttId = content.select("input[type=hidden][name=nttId]").val();
-            // [공지]가 아닌 게시글이라면
-            if(!nttId.isEmpty()) {
-                checkFirstBoardTitle = doCrawlAtFirst(content, checkFirstBoardTitle, boardType, articleURL, nttId, boardDTOList);
-            }
-        }
+        return List.of(contents, htmlDocDTO);
     }
 
-    /**
-     * 서버가 처음 실행된게 아닐 때, 실행되는 크롤링
-     */
-    /**
-     * 이미지 태그를 기준으로 새로운 게시글을 판단합니다.
-     */
-
-    private void crawlAtServerIsNotFirst(Elements contents, boolean checkFirstBoardTitle, byte boardType, String articleURL, List<BoardDTO> boardDTOList) throws IOException {
-        for (Element content : contents) {
-            String nttId = content.select("input[type=hidden][name=nttId]").val();
-            // [공지]가 아닌 게시글이라면
-            if(!nttId.isEmpty()) {
-                if (extractImageTag(content)) break;
-                // 게시글의 제목을 추출.
-                String newTitle = content.select("td.left > div > div > form > input[type=submit]").val();
-                // 'N' 이미지 태그가 있고, 처음 게시물을 검사한다면.
-                if(checkFirstBoardTitle) {
-                    // 'N' 이미지 태그가 있고, 기존 첫 게시글의 제목과 새로 가져온 게시글이 같다면 종료
-                    if(boardTitles[boardType].equals(newTitle)) {
-                        log.info("[Crawling-Worker] 'N' 이미지 태그가 있지만, 기존 첫 게시글의 제목과 새로 가져온 게시물이 같다면 종료");
-                        break;
-                    }
-                    checkFirstBoardTitle = doCrawlAtSecond(content, boardType, newTitle, articleURL, nttId, boardDTOList, checkFirstBoardTitle);
-
-                } else {
-                    // 'N' 이미지 태그가 있고, 처음 게시물을 검사하는게 아니라면
-                    // 하위 모든 게시글을 전부 추출.
-                    // 기존에 10개를 가져오고 10개를 삭제하는 것이므로, 새로운 게시글을 포함해서 하위 10개를 가지고옴.
-                    getNewBoard(content, articleURL, nttId, boardDTOList);
-                }
-
-            }
-        }
-    }
-
-    private boolean doCrawlAtFirst(Element content, boolean checkFirstBoardTitle, byte boardType, String articleURL, String nttId, List<BoardDTO> boardDTOList) throws IOException {
-        // 게시글의 제목을 추출.
-        String newTitle = content.select("td.left > div > div > form > input[type=submit]").val();
-        // 첫번째 게시글의 제목을 boarTitles 저장.
-        if(checkFirstBoardTitle) {
-            boardTitles[boardType] = newTitle;
-        }
-        // 첫번째 게시글을 포함해서, 하위 10개의 데이터를 전부 데이터 베이스에 업데이트.
-        getNewBoard(content, articleURL, nttId, boardDTOList);
-        return false;
-    }
-
-    private boolean doCrawlAtSecond(Element content, byte boardType, String newTitle, String articleURL, String nttId, List<BoardDTO> boardDTOList, boolean checkFirstBoardTitle) throws IOException {
-        // 'N' 이미지 태그가 있고, 처음 게시물의 '제목'이 기존에 저장했던 처음 게시물의 '제목'과 다르다면,
-        // 이전 게시물을 처음 게시물로 교체.
-        // 처음 게시물을 업데이트에 포함.
-        if (!boardTitles[boardType].equals(newTitle)) {
-            boardTitles[boardType] = newTitle;
-            getNewBoard(content, articleURL, nttId, boardDTOList);
-            checkFirstBoardTitle = false;
-        }
-        return checkFirstBoardTitle;
-    }
 
     /**
      * 이미지 태그를 추출합니다.
      */
-    private static boolean extractImageTag(Element content) {
+    private boolean extractImageTag(Element content) {
         // 'N' 이미지 태그를 추출.
         Elements newImageTag = content.select("td.left > div > div > form > img");
         // 'N' 이미지 태그가 없다면 기존 게시글이며 크롤링 중지.

--- a/src/main/java/com/fx/knutNotice/worker/BoardCrawlingWorker.java
+++ b/src/main/java/com/fx/knutNotice/worker/BoardCrawlingWorker.java
@@ -16,8 +16,6 @@ import org.jsoup.select.Elements;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StopWatch;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;


### PR DESCRIPTION
1. 크롤링 로직에서 코드가 중복되는 부분이 있었습니다. 그래서 중복되는 코드를 제거 했고, 메소드 이름을 좀 더 명확하게 변경했습니다.
2. 모듈이 너무 세분화 되어 있어, 불필요하게 모듈이 분리되는 문제가 있는것 같아 모듈을 다시 분리했습니다.