### PR TITLE
🐛fix: 학사공지사항 날짜 크롤링 수정

### DIFF
--- a/src/main/java/com/fx/knutNotice/worker/BoardCrawlingWorker.java
+++ b/src/main/java/com/fx/knutNotice/worker/BoardCrawlingWorker.java
@@ -183,8 +183,7 @@ public class BoardCrawlingWorker {
         String boardNumber = content.select("td.problem_number").text();
 
         String departName = content.select("td.problem_name").text();
-        String registrationDate = content.select("td.date").text();
-
+        String registrationDate = content.select("td.date").get(0).text();
 
         //nttId에 대한 내용 크롤링
         //nttId에 해당하는 게시글 URL


### PR DESCRIPTION
🐛fix: 학사공지사항 날짜 크롤링 수정


```
        String registrationDate = content.select("td.date").text();
```
학사공지사항일 경우 등록일과 시행일로 나뉘어져 있어 아래와 같이 등록일만 크롤링하도록 수정
```
        String registrationDate = content.select("td.date").get(0).text();
```